### PR TITLE
feat: add createVueReduxPlugin for Vue .use() pattern

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -32,9 +32,25 @@ Vue-Redux is written in TypeScript, so all types are automatically included.
 
 ## API Overview
 
+### `createVueReduxPlugin`
+
+Vue Redux provides a `createVueReduxPlugin` function that creates a Vue plugin to provide the Redux store to your app:
+
+```typescript
+import { createApp } from 'vue'
+import { createVueReduxPlugin } from '@reduxjs/vue-redux'
+import { store } from './store'
+
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(createVueReduxPlugin({ store }))
+app.mount('#app')
+```
+
 ### `provideStoreToApp`
 
-Vue Redux includes a `provideStoreToApp` function, which makes the Redux store available to the rest of your app:
+Alternatively, you can use `provideStoreToApp` directly without the plugin pattern:
 
 ```typescript
 import { createApp } from 'vue'

--- a/packages/vue-redux/src/index.ts
+++ b/packages/vue-redux/src/index.ts
@@ -1,5 +1,6 @@
 export * from './provider/provider'
 export * from './provider/context'
+export * from './plugin'
 export * from './compositions/use-store'
 export * from './compositions/use-dispatch'
 export * from './compositions/use-selector'

--- a/packages/vue-redux/src/plugin.ts
+++ b/packages/vue-redux/src/plugin.ts
@@ -1,0 +1,34 @@
+import { provideStoreToApp } from './provider/provider'
+import type { ProviderProps } from './provider/provider'
+import type { App, Plugin } from 'vue'
+import type { Action, UnknownAction } from 'redux'
+
+export interface VueReduxPluginOptions<
+  A extends Action<string> = UnknownAction,
+  S = unknown,
+> extends ProviderProps<A, S> {}
+
+/**
+ * Creates a Vue plugin that provides the Redux store to the entire application.
+ *
+ * @example
+ * ```ts
+ * import { createApp } from 'vue'
+ * import { createVueReduxPlugin } from '@reduxjs/vue-redux'
+ * import { store } from './store'
+ *
+ * const app = createApp(App)
+ * app.use(createVueReduxPlugin({ store }))
+ * app.mount('#app')
+ * ```
+ */
+export function createVueReduxPlugin<
+  A extends Action<string> = UnknownAction,
+  S = unknown,
+>(options: VueReduxPluginOptions<A, S>): Plugin {
+  return {
+    install(app: App) {
+      provideStoreToApp(app, options)
+    },
+  }
+}

--- a/packages/vue-redux/tests/plugin.spec.tsx
+++ b/packages/vue-redux/tests/plugin.spec.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent } from 'vue'
+import { createStore } from 'redux'
+import { createVueReduxPlugin, useDispatch, useSelector } from '../src'
+
+const store = createStore((c: number = 0, action: { type: string }) => {
+  if (action.type === 'INCREMENT') return c + 1
+  return c
+})
+
+describe('Vue', () => {
+  describe('plugin', () => {
+    describe('createVueReduxPlugin', () => {
+      it('provides the store to the application', () => {
+        let capturedDispatch: unknown
+        let capturedState: unknown
+
+        const Comp = defineComponent({
+          setup() {
+            capturedDispatch = useDispatch()
+            capturedState = useSelector((state: number) => state)
+            return () => null
+          },
+        })
+
+        const app = createApp(Comp)
+        app.use(createVueReduxPlugin({ store }))
+
+        const div = document.createElement('div')
+        app.mount(div)
+
+        expect(capturedDispatch).toBe(store.dispatch)
+        expect(capturedState).toBe(store.getState())
+
+        app.unmount()
+      })
+
+      it('works with multiple components', () => {
+        let dispatchA: unknown
+        let dispatchB: unknown
+
+        const CompA = defineComponent({
+          setup() {
+            dispatchA = useDispatch()
+            return () => null
+          },
+        })
+
+        const CompB = defineComponent({
+          setup() {
+            dispatchB = useDispatch()
+            return () => null
+          },
+        })
+
+        const Root = defineComponent({
+          components: { CompA, CompB },
+          template: '<CompA /><CompB />',
+        })
+
+        const app = createApp(Root)
+        app.use(createVueReduxPlugin({ store }))
+
+        const div = document.createElement('div')
+        app.mount(div)
+
+        expect(dispatchA).toBe(store.dispatch)
+        expect(dispatchB).toBe(store.dispatch)
+
+        app.unmount()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds a `createVueReduxPlugin` function that creates a Vue plugin for providing the Redux store to an application. It wraps `provideStoreToApp` in the standard Vue plugin interface.

With this change, users can set up Redux using the idiomatic Vue pattern:

```typescript
import { createApp } from 'vue'
import { createVueReduxPlugin } from '@reduxjs/vue-redux'
import { store } from './store'

const app = createApp(App)
app.use(createVueReduxPlugin({ store }))
app.mount('#app')
```

Changes:
- Added `plugin.ts` with `createVueReduxPlugin` and `VueReduxPluginOptions`
- Exported the plugin from the package entry point
- Added tests covering basic usage
- Updated the getting-started docs to show the plugin approach

Closes #2
